### PR TITLE
Add the report date to the bug post

### DIFF
--- a/df-bug-bot.lisp
+++ b/df-bug-bot.lisp
@@ -32,7 +32,7 @@
 (defun generate-post ()
   "generates a post"
   (let ((bug (get-random-bug)))
-    (format nil "~A: ~A" (nth 0 bug) (nth 11 bug))))
+    (format nil "(~A) ~A: ~A" (nth 8 bug) (nth 0 bug) (nth 11 bug))))
 
 (defun main ()
   "main binary entry point"


### PR DESCRIPTION
Adding the report date to the bug post to give more context to the bug and show its possible historicity.